### PR TITLE
feat: AI対戦機能の実装 (Issue #9)

### DIFF
--- a/backend/src/main/java/com/japanesechess/ai/AiDifficulty.java
+++ b/backend/src/main/java/com/japanesechess/ai/AiDifficulty.java
@@ -1,0 +1,23 @@
+package com.japanesechess.ai;
+
+public enum AiDifficulty {
+    BEGINNER(0, "初級"),
+    INTERMEDIATE(2, "中級"),
+    ADVANCED(4, "上級");
+
+    private final int searchDepth;
+    private final String japaneseName;
+
+    AiDifficulty(int searchDepth, String japaneseName) {
+        this.searchDepth = searchDepth;
+        this.japaneseName = japaneseName;
+    }
+
+    public int getSearchDepth() {
+        return searchDepth;
+    }
+
+    public String getJapaneseName() {
+        return japaneseName;
+    }
+}

--- a/backend/src/main/java/com/japanesechess/ai/AiGameService.java
+++ b/backend/src/main/java/com/japanesechess/ai/AiGameService.java
@@ -1,0 +1,72 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.aggregate.Game;
+import com.japanesechess.command.MovePieceCommand;
+import com.japanesechess.command.DropPieceCommand;
+import com.japanesechess.domain.*;
+import com.japanesechess.repository.GameRepository;
+import com.japanesechess.service.GameCommandHandler;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class AiGameService {
+
+    private final GameRepository gameRepository;
+    private final GameCommandHandler commandHandler;
+    private final MinimaxEngine minimaxEngine = new MinimaxEngine();
+
+    public AiGameService(GameRepository gameRepository, GameCommandHandler commandHandler) {
+        this.gameRepository = gameRepository;
+        this.commandHandler = commandHandler;
+    }
+
+    public Optional<AiMoveResult> makeAiMove(UUID gameId, PlayerColor aiColor, AiDifficulty difficulty) {
+        Game game = gameRepository.findById(gameId)
+            .orElseThrow(() -> new IllegalArgumentException("Game not found: " + gameId));
+
+        if (game.getStatus() != Game.GameStatus.IN_PROGRESS) {
+            return Optional.empty();
+        }
+
+        if (game.getCurrentTurn() != aiColor) {
+            return Optional.empty();
+        }
+
+        Board board = game.getBoard();
+        Optional<Move> bestMove = minimaxEngine.findBestMove(board, aiColor, difficulty);
+
+        if (bestMove.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Move move = bestMove.get();
+        executeMove(gameId, move);
+
+        return Optional.of(new AiMoveResult(move, aiColor, difficulty));
+    }
+
+    private void executeMove(UUID gameId, Move move) {
+        if (move.isDrop()) {
+            DropPieceCommand command = new DropPieceCommand(
+                gameId,
+                move.getPlayer(),
+                move.getTo(),
+                move.getPieceType()
+            );
+            commandHandler.handle(command);
+        } else {
+            MovePieceCommand command = new MovePieceCommand(
+                gameId,
+                move.getPlayer(),
+                move.getFrom(),
+                move.getTo(),
+                move.isPromote(),
+                move.getPieceType()
+            );
+            commandHandler.handle(command);
+        }
+    }
+}

--- a/backend/src/main/java/com/japanesechess/ai/AiMoveGenerator.java
+++ b/backend/src/main/java/com/japanesechess/ai/AiMoveGenerator.java
@@ -1,0 +1,70 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class AiMoveGenerator {
+
+    private final MoveValidator moveValidator = new MoveValidator();
+
+    public List<Move> generateAllLegalMoves(Board board, PlayerColor player) {
+        List<Move> legalMoves = new ArrayList<>();
+
+        for (Piece piece : board.getPiecesForPlayer(player)) {
+            legalMoves.addAll(generateMovesForPiece(board, piece));
+        }
+
+        legalMoves.addAll(generateDropMoves(board, player));
+
+        return legalMoves;
+    }
+
+    private List<Move> generateMovesForPiece(Board board, Piece piece) {
+        List<Move> moves = new ArrayList<>();
+        Position from = piece.getPosition();
+        PlayerColor player = piece.getOwner();
+
+        for (int row = 0; row < 9; row++) {
+            for (int col = 0; col < 9; col++) {
+                Position to = new Position(row, col);
+
+                Move normalMove = Move.normalMove(from, to, piece.getType(), player);
+                if (moveValidator.isValidMove(board, normalMove)) {
+                    moves.add(normalMove);
+                }
+
+                if (piece.canPromoteAt(to)) {
+                    Move promoteMove = Move.promoteMove(from, to, piece.getType(), player);
+                    if (moveValidator.isValidMove(board, promoteMove)) {
+                        moves.add(promoteMove);
+                    }
+                }
+            }
+        }
+
+        return moves;
+    }
+
+    private List<Move> generateDropMoves(Board board, PlayerColor player) {
+        List<Move> moves = new ArrayList<>();
+        Set<PieceType> capturedPieces = new HashSet<>(board.getCapturedPieces(player));
+
+        for (PieceType pieceType : capturedPieces) {
+            for (int row = 0; row < 9; row++) {
+                for (int col = 0; col < 9; col++) {
+                    Position to = new Position(row, col);
+                    Move dropMove = Move.dropMove(to, pieceType, player);
+                    if (moveValidator.isValidMove(board, dropMove)) {
+                        moves.add(dropMove);
+                    }
+                }
+            }
+        }
+
+        return moves;
+    }
+}

--- a/backend/src/main/java/com/japanesechess/ai/AiMoveResult.java
+++ b/backend/src/main/java/com/japanesechess/ai/AiMoveResult.java
@@ -1,0 +1,36 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.Move;
+import com.japanesechess.domain.PlayerColor;
+
+public class AiMoveResult {
+    private final Move move;
+    private final PlayerColor aiColor;
+    private final AiDifficulty difficulty;
+
+    public AiMoveResult(Move move, PlayerColor aiColor, AiDifficulty difficulty) {
+        this.move = move;
+        this.aiColor = aiColor;
+        this.difficulty = difficulty;
+    }
+
+    public Move getMove() {
+        return move;
+    }
+
+    public PlayerColor getAiColor() {
+        return aiColor;
+    }
+
+    public AiDifficulty getDifficulty() {
+        return difficulty;
+    }
+
+    public boolean isDrop() {
+        return move.isDrop();
+    }
+
+    public String getMoveDescription() {
+        return move.toString();
+    }
+}

--- a/backend/src/main/java/com/japanesechess/ai/BoardEvaluator.java
+++ b/backend/src/main/java/com/japanesechess/ai/BoardEvaluator.java
@@ -1,0 +1,70 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.*;
+
+import java.util.List;
+
+public class BoardEvaluator {
+
+    private static final int KING_VALUE = 10000;
+    private static final int ROOK_VALUE = 1040;
+    private static final int BISHOP_VALUE = 890;
+    private static final int GOLD_VALUE = 600;
+    private static final int SILVER_VALUE = 560;
+    private static final int KNIGHT_VALUE = 410;
+    private static final int LANCE_VALUE = 370;
+    private static final int PAWN_VALUE = 100;
+
+    private static final int PROMOTED_ROOK_VALUE = 1200;
+    private static final int PROMOTED_BISHOP_VALUE = 1050;
+    private static final int PROMOTED_SILVER_VALUE = 640;
+    private static final int PROMOTED_KNIGHT_VALUE = 470;
+    private static final int PROMOTED_LANCE_VALUE = 430;
+    private static final int PROMOTED_PAWN_VALUE = 400;
+
+    private static final int CAPTURED_PIECE_BONUS = 115;
+
+    public int evaluate(Board board, PlayerColor perspective) {
+        int score = 0;
+
+        for (Piece piece : board.getAllPieces()) {
+            int value = getPieceValue(piece.getType());
+            if (piece.getOwner() == perspective) {
+                score += value;
+            } else {
+                score -= value;
+            }
+        }
+
+        List<PieceType> myCaptured = board.getCapturedPieces(perspective);
+        for (PieceType pieceType : myCaptured) {
+            score += (int) (getPieceValue(pieceType) * CAPTURED_PIECE_BONUS / 100.0);
+        }
+
+        List<PieceType> opponentCaptured = board.getCapturedPieces(perspective.opposite());
+        for (PieceType pieceType : opponentCaptured) {
+            score -= (int) (getPieceValue(pieceType) * CAPTURED_PIECE_BONUS / 100.0);
+        }
+
+        return score;
+    }
+
+    private int getPieceValue(PieceType type) {
+        return switch (type) {
+            case KING -> KING_VALUE;
+            case ROOK -> ROOK_VALUE;
+            case BISHOP -> BISHOP_VALUE;
+            case GOLD -> GOLD_VALUE;
+            case SILVER -> SILVER_VALUE;
+            case KNIGHT -> KNIGHT_VALUE;
+            case LANCE -> LANCE_VALUE;
+            case PAWN -> PAWN_VALUE;
+            case PROMOTED_ROOK -> PROMOTED_ROOK_VALUE;
+            case PROMOTED_BISHOP -> PROMOTED_BISHOP_VALUE;
+            case PROMOTED_SILVER -> PROMOTED_SILVER_VALUE;
+            case PROMOTED_KNIGHT -> PROMOTED_KNIGHT_VALUE;
+            case PROMOTED_LANCE -> PROMOTED_LANCE_VALUE;
+            case PROMOTED_PAWN -> PROMOTED_PAWN_VALUE;
+        };
+    }
+}

--- a/backend/src/main/java/com/japanesechess/ai/MinimaxEngine.java
+++ b/backend/src/main/java/com/japanesechess/ai/MinimaxEngine.java
@@ -1,0 +1,111 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+public class MinimaxEngine {
+
+    private static final int POSITIVE_INFINITY = Integer.MAX_VALUE / 2;
+    private static final int NEGATIVE_INFINITY = Integer.MIN_VALUE / 2;
+    private static final long MAX_SEARCH_TIME_MS = 10_000;
+
+    private final AiMoveGenerator moveGenerator = new AiMoveGenerator();
+    private final BoardEvaluator evaluator = new BoardEvaluator();
+    private final Random random = new Random();
+
+    private long searchStartTime;
+
+    public Optional<Move> findBestMove(Board board, PlayerColor player, AiDifficulty difficulty) {
+        int depth = difficulty.getSearchDepth();
+
+        if (depth == 0) {
+            return findRandomMove(board, player);
+        }
+
+        searchStartTime = System.currentTimeMillis();
+
+        List<Move> legalMoves = moveGenerator.generateAllLegalMoves(board, player);
+        if (legalMoves.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Move bestMove = legalMoves.get(0);
+        int bestScore = NEGATIVE_INFINITY;
+
+        for (Move move : legalMoves) {
+            if (isTimeExceeded()) {
+                break;
+            }
+
+            Board nextBoard = board.applyMove(move);
+            int score = minimax(nextBoard, depth - 1, NEGATIVE_INFINITY, POSITIVE_INFINITY, false, player);
+
+            if (score > bestScore) {
+                bestScore = score;
+                bestMove = move;
+            }
+        }
+
+        return Optional.of(bestMove);
+    }
+
+    private boolean isTimeExceeded() {
+        return System.currentTimeMillis() - searchStartTime > MAX_SEARCH_TIME_MS;
+    }
+
+    private Optional<Move> findRandomMove(Board board, PlayerColor player) {
+        List<Move> legalMoves = moveGenerator.generateAllLegalMoves(board, player);
+        if (legalMoves.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(legalMoves.get(random.nextInt(legalMoves.size())));
+    }
+
+    private int minimax(Board board, int depth, int alpha, int beta, boolean isMaximizing, PlayerColor aiPlayer) {
+        if (depth == 0 || isTimeExceeded()) {
+            return evaluator.evaluate(board, aiPlayer);
+        }
+
+        PlayerColor currentPlayer = isMaximizing ? aiPlayer : aiPlayer.opposite();
+        List<Move> legalMoves = moveGenerator.generateAllLegalMoves(board, currentPlayer);
+
+        if (legalMoves.isEmpty()) {
+            return isMaximizing ? NEGATIVE_INFINITY : POSITIVE_INFINITY;
+        }
+
+        if (isMaximizing) {
+            int maxScore = NEGATIVE_INFINITY;
+            for (Move move : legalMoves) {
+                if (isTimeExceeded()) {
+                    break;
+                }
+                Board nextBoard = board.applyMove(move);
+                int score = minimax(nextBoard, depth - 1, alpha, beta, false, aiPlayer);
+                maxScore = Math.max(maxScore, score);
+                alpha = Math.max(alpha, score);
+                if (beta <= alpha) {
+                    break;
+                }
+            }
+            return maxScore;
+        } else {
+            int minScore = POSITIVE_INFINITY;
+            for (Move move : legalMoves) {
+                if (isTimeExceeded()) {
+                    break;
+                }
+                Board nextBoard = board.applyMove(move);
+                int score = minimax(nextBoard, depth - 1, alpha, beta, true, aiPlayer);
+                minScore = Math.min(minScore, score);
+                beta = Math.min(beta, score);
+                if (beta <= alpha) {
+                    break;
+                }
+            }
+            return minScore;
+        }
+    }
+}

--- a/backend/src/main/java/com/japanesechess/api/AiController.java
+++ b/backend/src/main/java/com/japanesechess/api/AiController.java
@@ -1,0 +1,120 @@
+package com.japanesechess.api;
+
+import com.japanesechess.ai.AiDifficulty;
+import com.japanesechess.ai.AiGameService;
+import com.japanesechess.ai.AiMoveResult;
+import com.japanesechess.api.dto.AiMoveRequest;
+import com.japanesechess.api.dto.CreateAiGameRequest;
+import com.japanesechess.api.dto.GameResponse;
+import com.japanesechess.command.CreateGameCommand;
+import com.japanesechess.domain.PlayerColor;
+import com.japanesechess.service.GameCommandHandler;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/ai")
+public class AiController {
+
+    private static final UUID AI_PLAYER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private final GameCommandHandler commandHandler;
+    private final AiGameService aiGameService;
+
+    public AiController(GameCommandHandler commandHandler, AiGameService aiGameService) {
+        this.commandHandler = commandHandler;
+        this.aiGameService = aiGameService;
+    }
+
+    @PostMapping("/games")
+    public ResponseEntity<Map<String, Object>> createAiGame(
+        @Valid @RequestBody CreateAiGameRequest request
+    ) {
+        UUID gameId = UUID.randomUUID();
+        UUID humanPlayerId = request.getHumanPlayerId();
+        PlayerColor humanColor = request.getHumanColor();
+
+        UUID blackPlayerId = humanColor == PlayerColor.BLACK ? humanPlayerId : AI_PLAYER_ID;
+        UUID whitePlayerId = humanColor == PlayerColor.WHITE ? humanPlayerId : AI_PLAYER_ID;
+
+        CreateGameCommand command = new CreateGameCommand(gameId, blackPlayerId, whitePlayerId);
+        commandHandler.handle(command);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("gameId", gameId);
+        response.put("status", "created");
+        response.put("message", "AI game created successfully");
+        response.put("aiPlayerId", AI_PLAYER_ID);
+        response.put("humanPlayerId", humanPlayerId);
+        response.put("humanColor", humanColor.name());
+        response.put("aiColor", humanColor.opposite().name());
+        response.put("difficulty", request.getDifficulty().name());
+
+        if (humanColor == PlayerColor.WHITE) {
+            Optional<AiMoveResult> aiMove = aiGameService.makeAiMove(
+                gameId,
+                PlayerColor.BLACK,
+                request.getDifficulty()
+            );
+            aiMove.ifPresent(result -> {
+                response.put("aiFirstMove", result.getMoveDescription());
+            });
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/games/{gameId}/ai-move")
+    public ResponseEntity<Map<String, Object>> makeAiMove(
+        @PathVariable UUID gameId,
+        @Valid @RequestBody AiMoveRequest request
+    ) {
+        Optional<AiMoveResult> result = aiGameService.makeAiMove(
+            gameId,
+            request.getAiColor(),
+            request.getDifficulty()
+        );
+
+        Map<String, Object> response = new HashMap<>();
+
+        if (result.isPresent()) {
+            AiMoveResult aiMove = result.get();
+            response.put("success", true);
+            response.put("gameId", gameId);
+            response.put("moveDescription", aiMove.getMoveDescription());
+            response.put("isDrop", aiMove.isDrop());
+            response.put("aiColor", aiMove.getAiColor().name());
+            response.put("difficulty", aiMove.getDifficulty().name());
+        } else {
+            response.put("success", false);
+            response.put("gameId", gameId);
+            response.put("message", "AI could not make a move (game may be over or it's not AI's turn)");
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/difficulties")
+    public ResponseEntity<List<Map<String, String>>> getDifficulties() {
+        List<Map<String, String>> difficulties = Arrays.stream(AiDifficulty.values())
+            .map(d -> {
+                Map<String, String> map = new HashMap<>();
+                map.put("value", d.name());
+                map.put("label", d.getJapaneseName());
+                return map;
+            })
+            .collect(Collectors.toList());
+
+        return ResponseEntity.ok(difficulties);
+    }
+}

--- a/backend/src/main/java/com/japanesechess/api/dto/AiMoveRequest.java
+++ b/backend/src/main/java/com/japanesechess/api/dto/AiMoveRequest.java
@@ -1,0 +1,19 @@
+package com.japanesechess.api.dto;
+
+import com.japanesechess.ai.AiDifficulty;
+import com.japanesechess.domain.PlayerColor;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiMoveRequest {
+    @NotNull(message = "AI color is required")
+    private PlayerColor aiColor;
+
+    @NotNull(message = "Difficulty is required")
+    private AiDifficulty difficulty;
+}

--- a/backend/src/main/java/com/japanesechess/api/dto/CreateAiGameRequest.java
+++ b/backend/src/main/java/com/japanesechess/api/dto/CreateAiGameRequest.java
@@ -1,0 +1,24 @@
+package com.japanesechess.api.dto;
+
+import com.japanesechess.ai.AiDifficulty;
+import com.japanesechess.domain.PlayerColor;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAiGameRequest {
+    @NotNull(message = "Human player ID is required")
+    private UUID humanPlayerId;
+
+    @NotNull(message = "Human player color is required")
+    private PlayerColor humanColor;
+
+    @NotNull(message = "Difficulty is required")
+    private AiDifficulty difficulty;
+}

--- a/backend/src/test/java/com/japanesechess/ai/AiMoveGeneratorTest.java
+++ b/backend/src/test/java/com/japanesechess/ai/AiMoveGeneratorTest.java
@@ -1,0 +1,91 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("AiMoveGenerator - AI合法手生成クラス")
+class AiMoveGeneratorTest {
+
+    private AiMoveGenerator moveGenerator;
+
+    @BeforeEach
+    void setUp() {
+        moveGenerator = new AiMoveGenerator();
+    }
+
+    @Test
+    @DisplayName("初期配置からBLACKの合法手が生成される")
+    void shouldGenerateLegalMovesForBlackFromInitialPosition() {
+        Board board = Board.createInitialBoard();
+
+        List<Move> moves = moveGenerator.generateAllLegalMoves(board, PlayerColor.BLACK);
+
+        assertFalse(moves.isEmpty());
+        moves.forEach(move -> assertEquals(PlayerColor.BLACK, move.getPlayer()));
+    }
+
+    @Test
+    @DisplayName("初期配置からWHITEの合法手が生成される")
+    void shouldGenerateLegalMovesForWhiteFromInitialPosition() {
+        Board board = Board.createInitialBoard();
+
+        List<Move> moves = moveGenerator.generateAllLegalMoves(board, PlayerColor.WHITE);
+
+        assertFalse(moves.isEmpty());
+        moves.forEach(move -> assertEquals(PlayerColor.WHITE, move.getPlayer()));
+    }
+
+    @Test
+    @DisplayName("駒のない空の盤から合法手は生成されない")
+    void shouldReturnEmptyListFromEmptyBoard() {
+        Board board = new Board();
+
+        List<Move> moves = moveGenerator.generateAllLegalMoves(board, PlayerColor.BLACK);
+
+        assertTrue(moves.isEmpty());
+    }
+
+    @Test
+    @DisplayName("持ち駒があれば打ちの手が生成される")
+    void shouldGenerateDropMovesWhenCapturedPiecesExist() {
+        Board board = new Board();
+
+        board.placePiece(new Piece(PieceType.KING, PlayerColor.BLACK, new Position(8, 4)));
+        board.placePiece(new Piece(PieceType.KING, PlayerColor.WHITE, new Position(0, 4)));
+
+        Board boardWithCapture = board.applyMove(
+            Move.dropMove(new Position(5, 5), PieceType.PAWN, PlayerColor.BLACK)
+                .withCapturedPiece(PieceType.PAWN)
+        );
+
+        List<PieceType> captured = boardWithCapture.getCapturedPieces(PlayerColor.BLACK);
+        if (!captured.isEmpty()) {
+            List<Move> moves = moveGenerator.generateAllLegalMoves(boardWithCapture, PlayerColor.BLACK);
+            boolean hasDropMove = moves.stream().anyMatch(Move::isDrop);
+            assertTrue(hasDropMove || moves.isEmpty());
+        }
+    }
+
+    @Test
+    @DisplayName("初期配置から生成された全手は自玉を危険にさらさない")
+    void shouldNotGenerateMovesLeavingKingInCheck() {
+        Board board = Board.createInitialBoard();
+        CheckDetector checkDetector = new CheckDetector();
+
+        List<Move> moves = moveGenerator.generateAllLegalMoves(board, PlayerColor.BLACK);
+
+        for (Move move : moves) {
+            Board boardAfterMove = board.applyMove(move);
+            assertFalse(
+                checkDetector.isInCheck(boardAfterMove, PlayerColor.BLACK),
+                "Move should not leave own king in check: " + move
+            );
+        }
+    }
+}

--- a/backend/src/test/java/com/japanesechess/ai/BoardEvaluatorTest.java
+++ b/backend/src/test/java/com/japanesechess/ai/BoardEvaluatorTest.java
@@ -1,0 +1,83 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BoardEvaluator - 盤面評価クラス")
+class BoardEvaluatorTest {
+
+    private BoardEvaluator evaluator;
+
+    @BeforeEach
+    void setUp() {
+        evaluator = new BoardEvaluator();
+    }
+
+    @Test
+    @DisplayName("初期盤面の評価値は対称（双方0点）")
+    void shouldReturnZeroScoreForInitialBoard() {
+        Board board = Board.createInitialBoard();
+
+        int blackScore = evaluator.evaluate(board, PlayerColor.BLACK);
+        int whiteScore = evaluator.evaluate(board, PlayerColor.WHITE);
+
+        assertEquals(0, blackScore, "Black's score should be 0 on initial board");
+        assertEquals(0, whiteScore, "White's score should be 0 on initial board");
+    }
+
+    @Test
+    @DisplayName("飛車を持つ側の評価が高い")
+    void shouldEvaluateHigherWhenHavingRook() {
+        Board board = new Board();
+        board.placePiece(new Piece(PieceType.KING, PlayerColor.BLACK, new Position(8, 4)));
+        board.placePiece(new Piece(PieceType.KING, PlayerColor.WHITE, new Position(0, 4)));
+        board.placePiece(new Piece(PieceType.ROOK, PlayerColor.BLACK, new Position(7, 1)));
+
+        int blackScore = evaluator.evaluate(board, PlayerColor.BLACK);
+        int whiteScore = evaluator.evaluate(board, PlayerColor.WHITE);
+
+        assertTrue(blackScore > 0, "Black with rook should have positive score");
+        assertTrue(whiteScore < 0, "White without rook should have negative score");
+        assertEquals(-blackScore, whiteScore);
+    }
+
+    @Test
+    @DisplayName("評価は対称性を持つ（視点が変われば符号が反転する）")
+    void shouldBeSymmetric() {
+        Board board = Board.createInitialBoard();
+
+        board = board.applyMove(Move.normalMove(
+            new Position(6, 4), new Position(5, 4), PieceType.PAWN, PlayerColor.BLACK
+        ));
+
+        int blackPerspective = evaluator.evaluate(board, PlayerColor.BLACK);
+        int whitePerspective = evaluator.evaluate(board, PlayerColor.WHITE);
+
+        assertEquals(blackPerspective, -whitePerspective,
+            "Evaluation should be symmetric (opposite signs for opposite perspectives)");
+    }
+
+    @Test
+    @DisplayName("駒得した場合の評価が高い")
+    void shouldEvaluateHigherAfterCapture() {
+        Board boardBefore = new Board();
+        boardBefore.placePiece(new Piece(PieceType.KING, PlayerColor.BLACK, new Position(8, 4)));
+        boardBefore.placePiece(new Piece(PieceType.KING, PlayerColor.WHITE, new Position(0, 4)));
+        boardBefore.placePiece(new Piece(PieceType.ROOK, PlayerColor.BLACK, new Position(4, 4)));
+        boardBefore.placePiece(new Piece(PieceType.PAWN, PlayerColor.WHITE, new Position(3, 4)));
+
+        int scoreBefore = evaluator.evaluate(boardBefore, PlayerColor.BLACK);
+
+        Board boardAfter = boardBefore.applyMove(
+            Move.normalMove(new Position(4, 4), new Position(3, 4), PieceType.ROOK, PlayerColor.BLACK)
+        );
+        int scoreAfter = evaluator.evaluate(boardAfter, PlayerColor.BLACK);
+
+        assertTrue(scoreAfter > scoreBefore,
+            "Score should increase after capturing opponent's piece");
+    }
+}

--- a/backend/src/test/java/com/japanesechess/ai/MinimaxEngineTest.java
+++ b/backend/src/test/java/com/japanesechess/ai/MinimaxEngineTest.java
@@ -1,0 +1,93 @@
+package com.japanesechess.ai;
+
+import com.japanesechess.domain.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("MinimaxEngine - ミニマックスAIエンジン")
+class MinimaxEngineTest {
+
+    private MinimaxEngine engine;
+
+    @BeforeEach
+    void setUp() {
+        engine = new MinimaxEngine();
+    }
+
+    @Test
+    @DisplayName("初期配置から初級AIが手を返す")
+    void shouldReturnMoveFromInitialPositionBeginnerDifficulty() {
+        Board board = Board.createInitialBoard();
+
+        Optional<Move> move = engine.findBestMove(board, PlayerColor.BLACK, AiDifficulty.BEGINNER);
+
+        assertTrue(move.isPresent(), "Beginner AI should return a move from initial position");
+        assertEquals(PlayerColor.BLACK, move.get().getPlayer());
+    }
+
+    @Test
+    @DisplayName("初期配置から中級AIが手を返す")
+    void shouldReturnMoveFromInitialPositionIntermediateDifficulty() {
+        Board board = Board.createInitialBoard();
+
+        Optional<Move> move = engine.findBestMove(board, PlayerColor.BLACK, AiDifficulty.INTERMEDIATE);
+
+        assertTrue(move.isPresent(), "Intermediate AI should return a move from initial position");
+        assertEquals(PlayerColor.BLACK, move.get().getPlayer());
+    }
+
+    @Test
+    @DisplayName("AIの手は合法手")
+    void shouldReturnLegalMove() {
+        Board board = Board.createInitialBoard();
+        MoveValidator validator = new MoveValidator();
+
+        Optional<Move> move = engine.findBestMove(board, PlayerColor.BLACK, AiDifficulty.BEGINNER);
+
+        assertTrue(move.isPresent());
+        assertTrue(validator.isValidMove(board, move.get()),
+            "AI move should be a valid move");
+    }
+
+    @Test
+    @DisplayName("AIは明らかに有利な手（駒を取る手）を選ぶ（中級以上）")
+    void shouldPreferCaptureMoveAtIntermediateLevel() {
+        Board board = new Board();
+        board.placePiece(new Piece(PieceType.KING, PlayerColor.BLACK, new Position(8, 4)));
+        board.placePiece(new Piece(PieceType.ROOK, PlayerColor.BLACK, new Position(4, 4)));
+        board.placePiece(new Piece(PieceType.KING, PlayerColor.WHITE, new Position(0, 4)));
+        board.placePiece(new Piece(PieceType.PAWN, PlayerColor.WHITE, new Position(3, 4)));
+
+        Optional<Move> move = engine.findBestMove(board, PlayerColor.BLACK, AiDifficulty.INTERMEDIATE);
+
+        assertTrue(move.isPresent());
+        Move aiMove = move.get();
+        assertTrue(
+            aiMove.getTo().getRow() == 3 && aiMove.getTo().getColumn() == 4,
+            "Intermediate AI should capture the pawn with rook"
+        );
+    }
+
+    @Test
+    @DisplayName("合法手がない場合はemptyを返す")
+    void shouldReturnEmptyWhenNoLegalMoves() {
+        Board board = new Board();
+
+        Optional<Move> move = engine.findBestMove(board, PlayerColor.BLACK, AiDifficulty.BEGINNER);
+
+        assertFalse(move.isPresent(), "Should return empty when no pieces on board");
+    }
+
+    @Test
+    @DisplayName("初級はランダム、中級・上級はミニマックスで手を選ぶ")
+    void shouldUseDifferentStrategyByDifficulty() {
+        assertEquals(0, AiDifficulty.BEGINNER.getSearchDepth());
+        assertEquals(2, AiDifficulty.INTERMEDIATE.getSearchDepth());
+        assertEquals(4, AiDifficulty.ADVANCED.getSearchDepth());
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { GameDetailPage } from './pages/GameDetailPage'
 import { GameReplayPage } from './pages/GameReplayPage'
 import { StatisticsPage } from './pages/StatisticsPage'
 import { CreateGamePage } from './pages/CreateGamePage'
+import { CreateAiGamePage } from './pages/CreateAiGamePage'
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<GameListPage />} />
           <Route path="create" element={<CreateGamePage />} />
+          <Route path="create-ai" element={<CreateAiGamePage />} />
           <Route path="game/:gameId" element={<GameDetailPage />} />
           <Route path="replay/:gameId" element={<GameReplayPage />} />
           <Route path="statistics" element={<StatisticsPage />} />

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -79,6 +79,19 @@ export function GameList() {
             {isClearing ? 'クリア中...' : 'すべてクリア'}
           </button>
           <Link
+            to="/create-ai"
+            style={{
+              padding: '8px 16px',
+              backgroundColor: '#17a2b8',
+              color: 'white',
+              textDecoration: 'none',
+              borderRadius: '4px',
+              fontWeight: 'bold',
+            }}
+          >
+            AI対局
+          </Link>
+          <Link
             to="/create"
             style={{
               padding: '8px 16px',

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,6 +12,14 @@ export function Layout() {
             <Link to="/" className="nav-link">
               対局一覧
             </Link>
+            <Link to="/create-ai" className="nav-link" style={{
+              backgroundColor: '#28a745',
+              color: 'white',
+              padding: '6px 14px',
+              borderRadius: '4px',
+            }}>
+              AI対局
+            </Link>
             <Link to="/statistics" className="nav-link">
               統計
             </Link>

--- a/frontend/src/pages/CreateAiGamePage.tsx
+++ b/frontend/src/pages/CreateAiGamePage.tsx
@@ -1,0 +1,232 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api, AI_PLAYER_ID } from '../services/api'
+import type { AiDifficulty, PlayerColor } from '../services/api'
+
+const DIFFICULTY_LABELS: Record<AiDifficulty, string> = {
+  BEGINNER: '初級',
+  INTERMEDIATE: '中級',
+  ADVANCED: '上級',
+}
+
+const DIFFICULTY_DESCRIPTIONS: Record<AiDifficulty, string> = {
+  BEGINNER: 'ランダムに手を指します。将棋を始めたばかりの方向け。',
+  INTERMEDIATE: '2手先まで読んで指します。ある程度の挑戦になります。',
+  ADVANCED: '4手先まで読んで指します。強い相手と対局したい方向け。',
+}
+
+const COLOR_LABELS: Record<PlayerColor, string> = {
+  BLACK: '先手（黒）',
+  WHITE: '後手（白）',
+}
+
+export const CreateAiGamePage: React.FC = () => {
+  const navigate = useNavigate()
+  const [humanPlayerId] = useState(() => crypto.randomUUID())
+  const [humanColor, setHumanColor] = useState<PlayerColor>('BLACK')
+  const [difficulty, setDifficulty] = useState<AiDifficulty>('BEGINNER')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await api.createAiGame({
+        humanPlayerId,
+        humanColor,
+        difficulty,
+      })
+
+      let retries = 0
+      const maxRetries = 20
+      let gameFound = false
+
+      while (retries < maxRetries && !gameFound) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+
+        try {
+          await api.getGameById(response.gameId)
+          gameFound = true
+        } catch {
+          // ゲームがまだ見つからない
+        }
+
+        retries++
+      }
+
+      if (!gameFound) {
+        throw new Error('ゲームの作成に時間がかかっています。少し待ってから対局一覧から開いてください。')
+      }
+
+      navigate(`/game/${response.gameId}?playerId=${humanPlayerId}&aiPlayerId=${AI_PLAYER_ID}&aiColor=${response.aiColor}&difficulty=${difficulty}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'AI対局の作成に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '600px', margin: '0 auto', padding: '20px' }}>
+      <h1>AI対局の作成</h1>
+      <p style={{ color: '#666', marginBottom: '24px' }}>
+        コンピュータと将棋を対局できます。難易度を選んで挑戦してみましょう。
+      </p>
+
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '24px' }}>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', fontSize: '16px' }}>
+            手番を選択
+          </label>
+          <div style={{ display: 'flex', gap: '12px' }}>
+            {(['BLACK', 'WHITE'] as PlayerColor[]).map((color) => (
+              <button
+                key={color}
+                type="button"
+                onClick={() => setHumanColor(color)}
+                style={{
+                  flex: 1,
+                  padding: '16px',
+                  border: humanColor === color ? '2px solid #007bff' : '2px solid #ddd',
+                  borderRadius: '8px',
+                  backgroundColor: humanColor === color ? '#e7f3ff' : '#fff',
+                  cursor: 'pointer',
+                  fontSize: '15px',
+                  fontWeight: humanColor === color ? 'bold' : 'normal',
+                  color: humanColor === color ? '#007bff' : '#333',
+                  transition: 'all 0.2s',
+                }}
+              >
+                {COLOR_LABELS[color]}
+                {color === 'BLACK' && (
+                  <div style={{ fontSize: '12px', color: '#888', marginTop: '4px', fontWeight: 'normal' }}>
+                    先に指します
+                  </div>
+                )}
+                {color === 'WHITE' && (
+                  <div style={{ fontSize: '12px', color: '#888', marginTop: '4px', fontWeight: 'normal' }}>
+                    後から指します
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: '24px' }}>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', fontSize: '16px' }}>
+            難易度を選択
+          </label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            {(['BEGINNER', 'INTERMEDIATE', 'ADVANCED'] as AiDifficulty[]).map((level) => (
+              <button
+                key={level}
+                type="button"
+                onClick={() => setDifficulty(level)}
+                style={{
+                  padding: '14px 16px',
+                  border: difficulty === level ? '2px solid #28a745' : '2px solid #ddd',
+                  borderRadius: '8px',
+                  backgroundColor: difficulty === level ? '#e8f5e9' : '#fff',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  transition: 'all 0.2s',
+                }}
+              >
+                <div>
+                  <span style={{
+                    fontWeight: 'bold',
+                    fontSize: '15px',
+                    color: difficulty === level ? '#28a745' : '#333',
+                  }}>
+                    {DIFFICULTY_LABELS[level]}
+                  </span>
+                  <div style={{ fontSize: '13px', color: '#666', marginTop: '2px' }}>
+                    {DIFFICULTY_DESCRIPTIONS[level]}
+                  </div>
+                </div>
+                {difficulty === level && (
+                  <span style={{ color: '#28a745', fontSize: '18px' }}>✓</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error && (
+          <div
+            style={{
+              padding: '12px',
+              marginBottom: '20px',
+              backgroundColor: '#f8d7da',
+              color: '#721c24',
+              border: '1px solid #f5c6cb',
+              borderRadius: '4px',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <button
+            type="submit"
+            disabled={isLoading}
+            style={{
+              flex: 1,
+              padding: '14px',
+              backgroundColor: isLoading ? '#ccc' : '#28a745',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              fontSize: '16px',
+              fontWeight: 'bold',
+              cursor: isLoading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {isLoading ? 'AI対局を準備中...' : `AI（${DIFFICULTY_LABELS[difficulty]}）と対局開始`}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            style={{
+              padding: '14px 20px',
+              backgroundColor: '#6c757d',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              fontSize: '16px',
+              cursor: 'pointer',
+            }}
+          >
+            キャンセル
+          </button>
+        </div>
+      </form>
+
+      <div
+        style={{
+          marginTop: '30px',
+          padding: '15px',
+          backgroundColor: '#fff3cd',
+          border: '1px solid #ffc107',
+          borderRadius: '6px',
+        }}
+      >
+        <h3 style={{ marginTop: 0, color: '#856404' }}>AI対局について</h3>
+        <ul style={{ marginBottom: 0, color: '#856404' }}>
+          <li>先手（黒）が最初に指します</li>
+          <li>後手（白）を選ぶとAIが先手で最初の手を指してから対局が始まります</li>
+          <li>上級AIは計算に時間がかかる場合があります</li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/GameDetailPage.tsx
+++ b/frontend/src/pages/GameDetailPage.tsx
@@ -1,18 +1,24 @@
-import { useEffect, useState } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useEffect, useState, useCallback } from 'react'
+import { useParams, Link, useSearchParams } from 'react-router-dom'
 import { useGameStore } from '../stores/gameStore'
 import { Board } from '../components/Board'
 import { Hand } from '../components/Hand'
 import { api } from '../services/api'
+import type { AiDifficulty, PlayerColor } from '../services/api'
 import type { GameQueryDto, PieceType } from '../types/api'
 import { useGameWebSocket } from '../hooks/useGameWebSocket'
 
 export function GameDetailPage() {
   const { gameId } = useParams<{ gameId: string }>()
+  const [searchParams] = useSearchParams()
   const { currentGame, loading, error, fetchGame, clearError } = useGameStore()
   const [moveError, setMoveError] = useState<string | null>(null)
   const [isMoving, setIsMoving] = useState(false)
   const [selectedDropPiece, setSelectedDropPiece] = useState<PieceType | null>(null)
+
+  const aiColor = searchParams.get('aiColor') as PlayerColor | null
+  const difficulty = searchParams.get('difficulty') as AiDifficulty | null
+  const isAiGame = aiColor !== null && difficulty !== null
   const [showResignDialog, setShowResignDialog] = useState(false)
   const [showPromotionDialog, setShowPromotionDialog] = useState(false)
   const [pendingMove, setPendingMove] = useState<{
@@ -21,6 +27,17 @@ export function GameDetailPage() {
     piece: any
     playerId: string
   } | null>(null)
+
+  const triggerAiMove = useCallback(async () => {
+    if (!gameId || !aiColor || !difficulty) return
+
+    try {
+      await api.makeAiMove(gameId, { aiColor, difficulty })
+      await fetchGame(gameId)
+    } catch (err) {
+      setMoveError(err instanceof Error ? err.message : 'AIの手の実行に失敗しました')
+    }
+  }, [gameId, aiColor, difficulty, fetchGame])
 
   useEffect(() => {
     if (gameId) {
@@ -124,6 +141,10 @@ export function GameDetailPage() {
       })
       // Fallback fetch in case WebSocket is unavailable
       await fetchGame(gameId)
+
+      if (isAiGame) {
+        await triggerAiMove()
+      }
     } catch (err) {
       setMoveError(err instanceof Error ? err.message : '駒の移動に失敗しました')
     } finally {
@@ -183,6 +204,10 @@ export function GameDetailPage() {
       })
       // Fallback fetch in case WebSocket is unavailable
       await fetchGame(gameId)
+
+      if (isAiGame) {
+        await triggerAiMove()
+      }
     } catch (err) {
       setMoveError(err instanceof Error ? err.message : '駒を打つことに失敗しました')
     } finally {
@@ -383,7 +408,19 @@ export function GameDetailPage() {
         <Link to="/" className="back-link">
           ← 対局一覧に戻る
         </Link>
-        <h2>対局詳細</h2>
+        <h2>{isAiGame ? 'AI対局' : '対局詳細'}</h2>
+        {isAiGame && (
+          <span style={{
+            padding: '4px 12px',
+            backgroundColor: '#28a745',
+            color: 'white',
+            borderRadius: '12px',
+            fontSize: '13px',
+            fontWeight: 'bold',
+          }}>
+            AI対局 ({difficulty === 'BEGINNER' ? '初級' : difficulty === 'INTERMEDIATE' ? '中級' : '上級'})
+          </span>
+        )}
         {currentGame.moveCount > 0 && (
           <Link to={`/replay/${currentGame.gameId}`} className="replay-link">
             棋譜再生 (Replay) →
@@ -569,14 +606,19 @@ export function GameDetailPage() {
               marginBottom: '10px',
               borderRadius: '4px'
             }}>
-              駒を移動中...
+              {isAiGame && currentGame?.currentTurn === aiColor
+                ? 'AIが考えています...'
+                : '駒を移動中...'}
             </div>
           )}
           <Board
             boardState={currentGame.boardState}
             onMove={handleMove}
             onDrop={handleDrop}
-            interactive={currentGame.status === 'IN_PROGRESS'}
+            interactive={
+              currentGame.status === 'IN_PROGRESS' &&
+              (!isAiGame || currentGame.currentTurn !== aiColor)
+            }
             currentTurn={currentGame.currentTurn}
             dropMode={!!selectedDropPiece}
             dropPieceType={selectedDropPiece}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -39,6 +39,49 @@ interface GameResponse {
   nextTurn?: string
 }
 
+export type AiDifficulty = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED'
+export type PlayerColor = 'BLACK' | 'WHITE'
+
+export interface CreateAiGameRequest {
+  humanPlayerId: string
+  humanColor: PlayerColor
+  difficulty: AiDifficulty
+}
+
+export interface CreateAiGameResponse {
+  gameId: string
+  status: string
+  message: string
+  aiPlayerId: string
+  humanPlayerId: string
+  humanColor: PlayerColor
+  aiColor: PlayerColor
+  difficulty: AiDifficulty
+  aiFirstMove?: string
+}
+
+export interface AiMoveRequest {
+  aiColor: PlayerColor
+  difficulty: AiDifficulty
+}
+
+export interface AiMoveResponse {
+  success: boolean
+  gameId: string
+  moveDescription?: string
+  isDrop?: boolean
+  aiColor?: PlayerColor
+  difficulty?: AiDifficulty
+  message?: string
+}
+
+export interface AiDifficultyOption {
+  value: AiDifficulty
+  label: string
+}
+
+export const AI_PLAYER_ID = '00000000-0000-0000-0000-000000000001'
+
 export const api = {
   // Game Commands
   createGame: async (request: CreateGameRequest): Promise<GameResponse> => {
@@ -183,6 +226,22 @@ export const api = {
     const response = await axiosInstance.get<string>(
       `/queries/games/${gameId}/replay/kif`
     )
+    return response.data
+  },
+
+  // AI Game Commands
+  createAiGame: async (request: CreateAiGameRequest): Promise<CreateAiGameResponse> => {
+    const response = await axiosInstance.post<CreateAiGameResponse>('/ai/games', request)
+    return response.data
+  },
+
+  makeAiMove: async (gameId: string, request: AiMoveRequest): Promise<AiMoveResponse> => {
+    const response = await axiosInstance.post<AiMoveResponse>(`/ai/games/${gameId}/ai-move`, request)
+    return response.data
+  },
+
+  getAiDifficulties: async (): Promise<AiDifficultyOption[]> => {
+    const response = await axiosInstance.get<AiDifficultyOption[]>('/ai/difficulties')
     return response.data
   },
 }


### PR DESCRIPTION
## Summary

Issue #9 のAI対戦機能を実装しました。

- **バックエンド**: ミニマックスアルゴリズム + アルファベータ枝刈りによるAIエンジン
- **フロントエンド**: AI対局作成UI、難易度選択UI、AI自動応手
- **テスト**: AIロジックのユニットテスト15件

## 実装内容

### バックエンド

#### AIエンジン (`backend/src/main/java/com/japanesechess/ai/`)
- `AiDifficulty` - 難易度enum (BEGINNER=深さ0, INTERMEDIATE=深さ2, ADVANCED=深さ4)
- `AiMoveGenerator` - 全合法手生成 (重複除去最適化済み)
- `BoardEvaluator` - 駒の価値に基づく盤面評価関数
- `MinimaxEngine` - ミニマックス法 + アルファベータ枝刈り + 10秒タイムアウト
- `AiGameService` - AIサービス (既存GameCommandHandlerと連携)

#### API (`backend/src/main/java/com/japanesechess/api/`)
- `POST /api/ai/games` - AI対局作成 (難易度・手番選択)
- `POST /api/ai/games/{gameId}/ai-move` - AI手実行
- `GET /api/ai/difficulties` - 難易度一覧取得

### フロントエンド
- `CreateAiGamePage` - AI対局作成ページ (色・難易度選択UI)
- `GameDetailPage` - AI自動応手・AIターン表示の追加
- `Layout/GameList` - ナビゲーションにAI対局ボタン追加

### テスト
- `AiMoveGeneratorTest` - 合法手生成のユニットテスト (5件)
- `BoardEvaluatorTest` - 盤面評価のユニットテスト (4件)
- `MinimaxEngineTest` - AIエンジンのユニットテスト (6件)

## Test plan

- [ ] バックエンドAIテスト: `gradle test --tests "com.japanesechess.ai.*"` (全15件通過確認済み)
- [ ] AI対局作成: `/create-ai` から難易度選択して対局開始
- [ ] 初級AI: ランダムな手を指す動作確認
- [ ] 中級AI: 2手先読みで合法手を選ぶ動作確認
- [ ] 後手でAI対局開始: AIが先手で最初の手を指してから対局開始
- [ ] AI対局中のUI: AIターン時は盤面が操作不可、「AIが考えています...」表示
- [ ] 詰み検出: AIが詰みになると対局終了

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)